### PR TITLE
Fix score parsing failed because of DataPuller API change

### DIFF
--- a/BeatSaber_FakeMultiplay/Shared/Models/BsDataPuller/LiveData.cs
+++ b/BeatSaber_FakeMultiplay/Shared/Models/BsDataPuller/LiveData.cs
@@ -16,7 +16,6 @@
         public int Combo { get; set; }
         public int Misses { get; set; }
         public float Accuracy { get; set; }
-        public int[] BlockHitScore { get; set; }
         public float PlayerHealth { get; set; }
         public int TimeElapsed { get; set; }
         public long unixTimestamp { get; set; }


### PR DESCRIPTION
DataPuller added `PreSwing`, `PostSwing`, `CenterSwing` object in `BloqHitData` resulting in parsing failed as it used to be an array.

Beat Saber Connect does not consume any of the BloqHitData in any of our features, the fix removes the data from the class. So the fix should be backward compatible.